### PR TITLE
partial lineups

### DIFF
--- a/lib/game/Assignment.ts
+++ b/lib/game/Assignment.ts
@@ -4,4 +4,5 @@ import Position from './Position';
 export default interface Assignment {
   player: Player;
   position: Position;
+  score?: number;
 }

--- a/lib/game/Game.ts
+++ b/lib/game/Game.ts
@@ -44,10 +44,11 @@ export default class Game {
           );
         }
 
-        // generate the lineup
+        // generate the lineup outcome
+        const lineup = new Lineup(frame);
         const lineupOutcome = Lineup.generateLineupOutcome(
           remainingPlayers,
-          frame
+          lineup
         );
 
         // store away the outcomes

--- a/lib/game/Game.ts
+++ b/lib/game/Game.ts
@@ -1,23 +1,20 @@
-import _ from 'lodash';
-import { populatePositionProbabilities } from '../probabilities';
 import Lineup from './Lineup';
 import Player from './Player';
+import Position from './Position';
 
 const NUM_FRAMES = 4;
+const MIN_PLAYERS_FOR_LINEUP = Position.ALL_POSITIONS.length;
 
 export default class Game {
   lineups: Lineup[] = [];
 
   static generateGame(players: Player[]): Game {
-    if (players.length < 5) {
+    if (players.length < MIN_PLAYERS_FOR_LINEUP) {
       throw new Error('not enough players for a Game');
     }
 
     const game = new Game();
     let frame = 1;
-
-    // populate the position probabilities
-    players.forEach(populatePositionProbabilities);
 
     while (frame <= NUM_FRAMES) {
       // (re)set the remaining players to the pool of players available
@@ -29,23 +26,18 @@ export default class Game {
           break;
         }
 
-        // if it's less than 5, add more to make it 5
-        if (remainingPlayers.length < 5) {
-          const otherPlayers = _.differenceBy(
-            players,
-            remainingPlayers,
-            (player) => player.name
-          );
-          const difference = 5 - remainingPlayers.length;
-
-          // shuffle the list of other players, and add the difference
-          remainingPlayers = remainingPlayers.concat(
-            _.shuffle(otherPlayers).slice(0, difference)
-          );
+        let lineup: Lineup;
+        if (remainingPlayers.length < MIN_PLAYERS_FOR_LINEUP) {
+          // if it's less than minimum, generate a partial lineup
+          lineup = Lineup.generatePartialLineup(remainingPlayers);
+          // reset the remaining players to the pool of players available
+          remainingPlayers = players;
+        } else {
+          // otherwise just create an empty lineup
+          lineup = new Lineup(frame);
         }
 
-        // generate the lineup outcome
-        const lineup = new Lineup(frame);
+        // generate the lineup outcome, using the existing lineup
         const lineupOutcome = Lineup.generateLineupOutcome(
           remainingPlayers,
           lineup

--- a/lib/game/Lineup.test.ts
+++ b/lib/game/Lineup.test.ts
@@ -60,7 +60,7 @@ describe('Lineup', () => {
 
       it('should error', () => {
         expect(() => {
-          Lineup.generateLineupOutcome(players);
+          Lineup.generateLineupOutcome(players, new Lineup(1));
         }).toThrow(/At least 5 players required/);
       });
     });
@@ -78,7 +78,7 @@ describe('Lineup', () => {
       let lineupOutcome: LineupOutcome;
       let lineup: Lineup;
       beforeAll(() => {
-        lineupOutcome = Lineup.generateLineupOutcome(players);
+        lineupOutcome = Lineup.generateLineupOutcome(players, new Lineup(1));
         lineup = lineupOutcome.lineup;
       });
 
@@ -131,7 +131,7 @@ describe('Lineup', () => {
       let lineupOutcome: LineupOutcome;
       let lineup: Lineup;
       beforeAll(() => {
-        lineupOutcome = Lineup.generateLineupOutcome(players);
+        lineupOutcome = Lineup.generateLineupOutcome(players, new Lineup(1));
         lineup = lineupOutcome.lineup;
       });
 
@@ -156,8 +156,42 @@ describe('Lineup', () => {
         expect(positionNames).toEqual(['PG', 'SG', 'SF', 'PF', 'C']);
       });
 
-      it('should generate a LineupOutcome without 5 remaining players', () => {
+      it('should generate a LineupOutcome with 5 remaining players', () => {
         expect(lineupOutcome.remainingPlayers.length).toEqual(5);
+      });
+    });
+
+    describe('with an existing Lineup', () => {
+      const assignedPlayers = [
+        new Player('power', Skill.DEFAULT_PF_SKILLS),
+        new Player('center', Skill.DEFAULT_C_SKILLS),
+      ];
+      assignedPlayers.forEach(populatePositionProbabilities);
+      const remainingPlayers = [
+        new Player('point', Skill.DEFAULT_PG_SKILLS),
+        new Player('shoot', Skill.DEFAULT_SG_SKILLS),
+        new Player('small', Skill.DEFAULT_SF_SKILLS),
+      ];
+      remainingPlayers.forEach(populatePositionProbabilities);
+
+      let lineupOutcome: LineupOutcome;
+      beforeAll(() => {
+        const existingLineup = new Lineup(1);
+        existingLineup.addAssignment(assignedPlayers[0], Position.PF);
+        existingLineup.addAssignment(assignedPlayers[1], Position.C);
+
+        lineupOutcome = Lineup.generateLineupOutcome(
+          remainingPlayers,
+          existingLineup
+        );
+      });
+
+      it('should generate a lineup of 5 players', () => {
+        expect(lineupOutcome.lineup.assignments.length).toEqual(5);
+      });
+
+      it('should generate a LineupOutcome without any remaining players', () => {
+        expect(lineupOutcome.remainingPlayers.length).toEqual(0);
       });
     });
   });

--- a/lib/game/Lineup.ts
+++ b/lib/game/Lineup.ts
@@ -121,10 +121,6 @@ export default class Lineup {
       let bestAssignments = positionsToFill.map((position): Assignment => {
         const bestPlayer = playersAvailable.reduce(
           (bestPlayer, currentPlayer) => {
-            if (!bestPlayer) {
-              return currentPlayer;
-            }
-
             if (
               currentPlayer.hasHigherPositionProbability(position, bestPlayer)
             ) {

--- a/lib/game/Lineup.ts
+++ b/lib/game/Lineup.ts
@@ -47,17 +47,18 @@ export default class Lineup {
     );
   }
 
-  static generateLineupOutcome(players: Player[], frame = 1): LineupOutcome {
-    if (!players || players.length < Position.ALL_POSITIONS.length) {
-      throw new Error(
-        `At least ${Position.ALL_POSITIONS.length} players required`
-      );
-    }
-
-    const lineup: Lineup = new Lineup(frame);
-    const playersAvailable = _.clone(players);
+  static generateLineupOutcome(
+    players: Player[],
+    lineup: Lineup
+  ): LineupOutcome {
     // randomize the positions to fill
     const positionsToFill = _.shuffle(lineup.findEmptyPositions());
+
+    if (!players || players.length < positionsToFill.length) {
+      throw new Error(`At least ${positionsToFill.length} players required`);
+    }
+
+    const playersAvailable = _.clone(players);
 
     // build the lineup per each position
     positionsToFill.forEach((position) => {

--- a/lib/game/README.md
+++ b/lib/game/README.md
@@ -17,6 +17,7 @@ Below is an outline of the class hierarchy used in the `lineup` codebase:
 - Assignment
   - player: Player
   - position: Position
+  - score?: number
 - Lineup
   - assignments: Assignment[]
   - frame: number
@@ -27,12 +28,20 @@ Below is an outline of the class hierarchy used in the `lineup` codebase:
 
 Below is the algorithm to generate a `Game`, which contains a set of `Lineup`s:
 
-### `generateGame`
+### `generateGame` : `Game`
 
-Given a list of `Player`s who each have a set of `Skill`s for each `Position`, this code uses the `probabilities` library to populate the list of `PositionProbability`s for each `Position` (easy for you to say).
+Expects as input a list of `Player`s, where each `Player` has a `PositionProbability` for each `Position`. This function uses a combination of `generateLineupOutcome` and `generatePartialLineup` to build 4 `Lineup`s for the `Game`.
 
-Once these probabilities are generated, generates a `Lineup` for each `frame` within a game.
+### `generateLineupOutcome` : `LineupOutcome`
 
-### `generateLineupOutcome`
+_(for each position, find best player)_
 
-Given a list of `Player`s who each have a `PositionProbability`, this code finds the `Player` with the highest `PositionProbability` for each `Position`, and generates an `Assignment` for that `Player` and `Position`.
+Accepts a list of `Player`s (who each have a `PositionProbability`) and a `Lineup`. This function finds the `Player` with the highest `PositionProbability` for each `Position`, and generates an `Assignment` for that `Player` and `Position`. We then add the `Assignment`s to the `Lineup`, and return the `Lineup` and list of `Player`s who were not assigned.
+
+### `generatePartialLineup` : `Lineup`
+
+_(for all players, find best position)_
+
+As the name indicates, this generates a `Lineup` without assignments for all positions.
+
+Accepts a list of `Player`s who each have a `PositionProbability`. This function creates a new `Lineup`, and assigns the `Player`s to their highest scoring `PositionProbability`, when compared to the other `Player`s.

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -25,6 +25,11 @@ describe('utils', () => {
           .sort();
         expect(positions).toEqual(expectedPositions);
       });
+      it('should populate position probabilities', () => {
+        players.forEach((player) => {
+          expect(player.positionProbabilities.length).toEqual(5);
+        });
+      });
     });
 
     describe('with odd divisible amount', () => {
@@ -73,6 +78,10 @@ describe('utils', () => {
 
       it('should return the team', () => {
         expect(generateTeam()).toEqual([player]);
+      });
+      it('should populate position probabilities', () => {
+        const players = generateTeam();
+        expect(players[0].positionProbabilities.length).toEqual(5);
       });
     });
 

--- a/lib/utils.test.ts
+++ b/lib/utils.test.ts
@@ -56,7 +56,7 @@ describe('utils', () => {
     beforeEach(() => {
       jest.resetModules();
       try {
-        accessSync('../my-team', constants.R_OK);
+        accessSync('./my-team.ts', constants.R_OK);
         virtual = false;
       } catch (err) {
         virtual = true;

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -2,6 +2,7 @@ import _ from 'lodash';
 import Player from './game/Player';
 import Position from './game/Position';
 import Skill from './game/Skill';
+import { populatePositionProbabilities } from './probabilities';
 
 export function generateRandomPlayers(amount: number): Player[] {
   // perform the division, and save off both the quotient and remainder
@@ -19,19 +20,24 @@ export function generateRandomPlayers(amount: number): Player[] {
   // randomize the list, and create a new player for each position
   return _(positions)
     .shuffle()
-    .map(
-      (position, index) =>
-        new Player(
-          `${position.name}_${index}`,
-          Skill.getDefaultSkills(position)
-        )
-    )
+    .map((position, index) => {
+      const player = new Player(
+        `${position.name}_${index}`,
+        Skill.getDefaultSkills(position)
+      );
+      populatePositionProbabilities(player);
+      return player;
+    })
     .value();
 }
 
 export function generateTeam(): Player[] {
   try {
-    return require('../my-team');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const players = require('../my-team');
+    // TODO is this the best place to do this?
+    players.forEach(populatePositionProbabilities);
+    return players;
   } catch (err) {
     return generateRandomPlayers(10);
   }


### PR DESCRIPTION
### Generate lineups based on existing lineup

Alter the way generateLineupOutcome functions to accept a Lineup object as input, and base the generation off the data found in that lineup. This sets the framework for creating partial lineups and fully populating those to a full lineup.

### generatePartialLineup

Add ability to generate a partial lineup given a set of players that we expect to be less than a full set required for a full lineup. This logic finds the best assignment for each player, selecting only one player per position, and repeating.

### use partial lineups in game generation

- While generating a game, when we are left with less than the minimum amount of players for a lineup, use the partial lineup instead.
- This also makes it possible to determine the lineups if we know the position probabilities. So add a test to verify.
- Move population of position probabilities to the utils (at least for now)